### PR TITLE
Fix sidebar margin in legacy dashboard

### DIFF
--- a/client/twoMB/src/legacy/LegacyDashboard.jsx
+++ b/client/twoMB/src/legacy/LegacyDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './legacy.css'
 
 export default function LegacyDashboard() {
@@ -13,6 +13,13 @@ export default function LegacyDashboard() {
       setSelectedMedal(medal)
     }
   }
+
+  useEffect(() => {
+    document.body.classList.add('has-sidebar')
+    return () => {
+      document.body.classList.remove('has-sidebar')
+    }
+  }, [])
 
   return (
     <div className="app-container">


### PR DESCRIPTION
## Summary
- ensure `.main-content` has sidebar margin by toggling `has-sidebar` class

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68723dadca08832aae22f506e990bcf2