### PR TITLE
Convert legacy dashboard to component-based React

### DIFF
--- a/client/twoMB/src/App.jsx
+++ b/client/twoMB/src/App.jsx
@@ -1,35 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import AppLayout from './layout/AppLayout';
+import Dashboard from './pages/Dashboard';
+import './styles/legacy.css';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <AppLayout>
+      <Dashboard />
+    </AppLayout>
+  );
 }
-
-export default App

--- a/client/twoMB/src/components/MedalDetails.jsx
+++ b/client/twoMB/src/components/MedalDetails.jsx
@@ -1,0 +1,18 @@
+import { medals } from '../constants/medals';
+
+export default function MedalDetails({ medalId, onClose }) {
+  const medal = medals.find(m => m.id === medalId);
+  if (!medal) return null;
+
+  return (
+    <div className="medal-details-container">
+      <div className="medal-details show" id={`${medal.id}-details`}>
+        <div className="medal-details-header">
+          <span className="medal-details-title">{medal.icon} {medal.name} 상세 정보</span>
+          <button className="close-details" onClick={onClose}>×</button>
+        </div>
+        <p className="empty-medal-message">아직 {medal.name}을 수령한 채널이 없습니다.</p>
+      </div>
+    </div>
+  );
+}

--- a/client/twoMB/src/components/cards/MedalCard.jsx
+++ b/client/twoMB/src/components/cards/MedalCard.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import MedalDetails from '../MedalDetails';
+import { medals } from '../../constants/medals';
+
+export default function MedalCard() {
+  const [selected, setSelected] = useState(null);
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">
+        <i className="fas fa-award" /> 메달 컬렉션
+      </h2>
+      <div className="medal-collection">
+        {medals.map(m => (
+          <button key={m.id} className="medal-button" onClick={() => setSelected(m.id)}>
+            <div className="medal-icon">{m.icon}</div>
+            <div className="medal-name">{m.name}</div>
+            <div className="medal-count">0개</div>
+          </button>
+        ))}
+      </div>
+      {selected && <MedalDetails medalId={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}

--- a/client/twoMB/src/components/cards/NotionCard.jsx
+++ b/client/twoMB/src/components/cards/NotionCard.jsx
@@ -1,0 +1,16 @@
+export default function NotionCard() {
+  return (
+    <div className="dashboard-card notion-card">
+      <a className="notion-link" href="#" target="_blank" rel="noreferrer">
+        <div className="notion-content">
+          <div className="notion-icon"><span style={{ fontSize: 60 }}>📝</span></div>
+          <div className="notion-text">
+            <h3>1기 수강생<br /> 학습 자료</h3>
+            <p>노션 보러가기</p>
+            <span className="notion-cta">바로가기 <i className="fas fa-external-link-alt" /></span>
+          </div>
+        </div>
+      </a>
+    </div>
+  );
+}

--- a/client/twoMB/src/components/modals/CompletedModal.jsx
+++ b/client/twoMB/src/components/modals/CompletedModal.jsx
@@ -1,0 +1,18 @@
+export default function CompletedModal({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="modal" onClick={onClose}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h3>학습 완료된 채널</h3>
+          <span className="close-modal" onClick={onClose}>×</span>
+        </div>
+        <div className="modal-body">
+          <div className="empty-message">
+            <p>아직 학습 완료된 채널이 없습니다.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/twoMB/src/components/modals/MyPostsModal.jsx
+++ b/client/twoMB/src/components/modals/MyPostsModal.jsx
@@ -1,0 +1,16 @@
+export default function MyPostsModal({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-container" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h3>내가 쓴 글</h3>
+          <button className="close-modal" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          <p>작성한 글이 없습니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/twoMB/src/components/modals/NotificationModal.jsx
+++ b/client/twoMB/src/components/modals/NotificationModal.jsx
@@ -1,0 +1,16 @@
+export default function NotificationModal({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-container" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h3>알림</h3>
+          <button className="close-modal" onClick={onClose}>×</button>
+        </div>
+        <div className="modal-body">
+          <p>새로운 알림이 없습니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/twoMB/src/constants/medals.js
+++ b/client/twoMB/src/constants/medals.js
@@ -1,0 +1,7 @@
+export const medals = [
+  { id: 'completion', icon: '🏆', name: '트로피' },
+  { id: 'gold', icon: '🥇', name: '금메달' },
+  { id: 'silver', icon: '🥈', name: '은메달' },
+  { id: 'bronze', icon: '🥉', name: '동메달' },
+  { id: 'copper', icon: '💮', name: '뱃지' },
+];

--- a/client/twoMB/src/hooks/useBodyClass.js
+++ b/client/twoMB/src/hooks/useBodyClass.js
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+
+export default function useBodyClass(className) {
+  useEffect(() => {
+    document.body.classList.add(className);
+    return () => document.body.classList.remove(className);
+  }, [className]);
+}

--- a/client/twoMB/src/layout/AppLayout.jsx
+++ b/client/twoMB/src/layout/AppLayout.jsx
@@ -1,0 +1,18 @@
+import Header from './Header';
+import Sidebar from './Sidebar';
+import useBodyClass from '../hooks/useBodyClass';
+
+export default function AppLayout({ children }) {
+  useBodyClass('has-sidebar');
+  return (
+    <div className="app-container">
+      <Header />
+      <Sidebar />
+      <main className="main-content">
+        <div className="content">
+          <div className="container">{children}</div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/twoMB/src/layout/Header.jsx
+++ b/client/twoMB/src/layout/Header.jsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import NotificationModal from '../components/modals/NotificationModal';
+import MyPostsModal from '../components/modals/MyPostsModal';
+
+export default function Header() {
+  const [showNotif, setShowNotif] = useState(false);
+  const [showPosts, setShowPosts] = useState(false);
+
+  return (
+    <header className="tubelab-header sidebar-open">
+      <div className="header-left">
+        <div className="menu-toggle" onClick={() => document.body.classList.toggle('sidebar-open')}>☰</div>
+      </div>
+      <div className="header-right">
+        <div className="notification-button" onClick={() => setShowNotif(true)}>🔔</div>
+        <div className="profile-container" onClick={() => setShowPosts(true)}>
+          <div className="profile-avatar">U</div>
+        </div>
+      </div>
+      <NotificationModal open={showNotif} onClose={() => setShowNotif(false)} />
+      <MyPostsModal open={showPosts} onClose={() => setShowPosts(false)} />
+    </header>
+  );
+}

--- a/client/twoMB/src/layout/Sidebar.jsx
+++ b/client/twoMB/src/layout/Sidebar.jsx
@@ -1,0 +1,15 @@
+export default function Sidebar() {
+  return (
+    <div className="tubelab-sidebar" id="sidebar">
+      <div className="sidebar-logo">
+        <div className="logo-box" style={{ backgroundColor: '#FF0033' }} />
+        <div className="logo-text">튜브랩</div>
+      </div>
+      <div className="sidebar-menu">
+        <div className="menu-section"><div>대시보드</div></div>
+        <div className="menu-section"><div>영상 업로드 캘린더</div></div>
+        <div className="menu-section"><div>나의 미션</div></div>
+      </div>
+    </div>
+  );
+}

--- a/client/twoMB/src/pages/Dashboard.jsx
+++ b/client/twoMB/src/pages/Dashboard.jsx
@@ -1,0 +1,22 @@
+import NotionCard from '../components/cards/NotionCard';
+import MedalCard from '../components/cards/MedalCard';
+import CompletedModal from '../components/modals/CompletedModal';
+import { useState } from 'react';
+
+export default function Dashboard() {
+  const [showCompleted, setShowCompleted] = useState(false);
+
+  return (
+    <div>
+      <h1 className="section-title">튜브랩 대시보드</h1>
+      <div className="dashboard-grid">
+        <NotionCard />
+        <MedalCard />
+      </div>
+      <button className="completed-channels-button" onClick={() => setShowCompleted(true)}>
+        학습 완료된 채널
+      </button>
+      <CompletedModal open={showCompleted} onClose={() => setShowCompleted(false)} />
+    </div>
+  );
+}

--- a/client/twoMB/src/styles/legacy.css
+++ b/client/twoMB/src/styles/legacy.css
@@ -1,0 +1,1337 @@
+
+        /* 노션 카드 스타일 */
+        .notion-card {
+            background: linear-gradient(135deg, #f5f5f5 0%, #ffffff 100%);
+            border: 2px solid #e0e0e0;
+            transition: all 0.3s ease;
+            overflow: hidden;
+        }
+
+        .notion-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            border-color: #000000;
+        }
+
+        .notion-link {
+            text-decoration: none;
+            color: inherit;
+            display: block;
+            height: 100%;
+        }
+
+        .notion-content {
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+            padding: 2rem;
+            height: 100%;
+            position: relative;
+        }
+
+        .notion-icon {
+            flex-shrink: 0;
+        }
+
+        .notion-logo {
+            width: 60px;
+            height: 60px;
+            object-fit: contain;
+        }
+
+        .notion-text h3 {
+            margin: 0 0 0.5rem 0;
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #333;
+        }
+
+        .notion-text p {
+            margin: 0 0 1rem 0;
+            color: #666;
+            font-size: 1rem;
+        }
+
+        .notion-cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: #000;
+            font-weight: 500;
+            font-size: 0.9rem;
+            transition: gap 0.3s ease;
+        }
+
+        .notion-card:hover .notion-cta {
+            gap: 1rem;
+        }
+
+        /* 리더 배지 */
+        .leader-badge {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background-color: #FFD700;
+            color: #333;
+            padding: 0.25rem 0.75rem;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+
+        /* 그룹 없음 카드 */
+        .no-group-card {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 200px;
+            background-color: #fafafa;
+            border: 2px dashed #ddd;
+        }
+
+        .no-group-content {
+            text-align: center;
+            padding: 2rem;
+        }
+
+        .no-group-content h3 {
+            margin: 0 0 0.5rem 0;
+            color: #666;
+        }
+
+        .no-group-content p {
+            margin: 0;
+            color: #999;
+        }
+
+        /* 반응형 디자인 */
+        @media (max-width: 768px) {
+            .notion-content {
+                flex-direction: column;
+                text-align: center;
+                padding: 1.5rem;
+                gap: 1rem;
+            }
+
+            .notion-logo {
+                width: 50px;
+                height: 50px;
+            }
+
+            .notion-text h3 {
+                font-size: 1.2rem;
+            }
+
+            .leader-badge {
+                position: static;
+                display: inline-block;
+                margin-top: 0.5rem;
+            }
+        }
+    
+
+    /* ===== 헤더/네비게이션 ===== */
+    .header,
+    .tubelab-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: var(--header-height);
+        background-color: #FFFFFF;
+        z-index: 1000;
+        border-bottom: 1px solid var(--border-color);
+        box-shadow: var(--shadow-sm);
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        transition: all 0.3s;
+    }
+
+    .profile-nickname {
+        font-weight: 600;
+        font-size: 14px;
+        color: #333;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-bottom: 2px;
+    }
+
+    /* 사이드바가 열려있을 때 헤더 조정 */
+    .header.sidebar-open,
+    .tubelab-header.sidebar-open {
+        margin-left: var(--sidebar-width);
+        width: calc(100% - var(--sidebar-width));
+    }
+
+    /* 레거시 지원 */
+    .nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: var(--header-height);
+        background-color: #FFFFFF;
+        z-index: 1000;
+        border-bottom: 1px solid var(--border-color);
+        box-shadow: var(--shadow-sm);
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        transition: all 0.3s;
+    }
+
+    /* 헤더 내부 요소 배치 */
+    .header-left,
+    .nav .logo-container {
+        display: flex;
+        align-items: center;
+    }
+
+    .header-right {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 15px;
+    }
+
+    /* 로고 스타일 */
+    .logo-container,
+    .logo-area {
+        display: flex;
+        align-items: center;
+    }
+
+    .logo {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        margin-right: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: hidden;
+        background-color: var(--primary-color);
+    }
+
+    .logo img {
+        max-width: 100%;
+        max-height: 100%;
+    }
+
+    .logo-text {
+        font-size: 18px;
+        font-weight: 700;
+        color: #111;
+    }
+
+    /* ===== 헤더 내 버튼 및 토글 ===== */
+    .menu-toggle {
+        display: none;
+        margin-right: 15px;
+        cursor: pointer;
+        color: var(--dark-gray);
+    }
+
+    .sidebar-toggle {
+        display: flex;
+        margin-right: 15px;
+        cursor: pointer;
+        z-index: 110;
+        color: var(--dark-gray);
+    }
+
+    /* 화면 너비가 768px 이하일 때 (모바일 환경) */
+    @media (max-width: 1024px) {
+        .menu-toggle { /* 모바일용 햄버거 버튼 */
+            display: flex; /* 모바일에서는 보이도록 변경 (또는 'block' 등 상황에 맞게) */
+            align-items: center; /* 아이콘 수직 정렬을 위해 추가 */
+        }
+
+        .sidebar-toggle { /* PC용 사이드바 접기/펼치기 버튼 */
+            display: none; /* 모바일에서는 숨기도록 변경 */
+        }
+
+        /* 추가적으로, 모바일에서 헤더의 패딩이나 다른 요소들 조정이 필요하다면 여기에 추가 */
+        /* 예시: 헤더 좌우 패딩 줄이기 */
+        /*
+        .header,
+        .tubelab-header {
+            padding: 0 15px;
+        }
+        */
+
+        /* 예시: 모바일에서 프로필 정보 간소화 (필요하다면) */
+        /*
+        .profile-info .profile-name,
+        .profile-info .profile-id {
+            display: none; // 닉네임만 보이게 하거나
+        }
+        .profile-info {
+            max-width: 100px; // 너비 조절
+        }
+        */
+    }
+
+    /* 사이드바 토글 아이콘 변경 스타일 */
+    .sidebar-toggle-icon {
+        transition: all 0.3s;
+    }
+
+    .sidebar-toggle-icon.collapsed .sidebar-icon {
+        display: inline-block;
+    }
+
+    .sidebar-toggle-icon.collapsed .close-icon {
+        display: none;
+    }
+
+    .sidebar-toggle-icon .sidebar-icon {
+        display: none;
+    }
+
+    .sidebar-toggle-icon .close-icon {
+        display: inline-block;
+    }
+
+    /* ===== 알림 버튼 스타일 ===== */
+    .notification-button {
+        position: relative;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        transition: all 0.3s;
+        color: var(--dark-gray);
+    }
+
+    .notification-button:hover {
+        background-color: #f5f5f5;
+    }
+
+    .notification-button svg {
+        width: 20px;
+        height: 20px;
+    }
+
+    /* 알림 뱃지 */
+    .notification-badge {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        background-color: #ff4757;
+        color: white;
+        font-size: 10px;
+        font-weight: 600;
+        min-width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 4px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    }
+
+    /* ===== 프로필 영역 스타일 ===== */
+    .profile-container {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        position: relative;
+        padding: 5px;
+        border-radius: 20px;
+        transition: all 0.3s;
+    }
+
+    .profile-container:hover {
+        background-color: #f5f5f5;
+    }
+
+    .profile-avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        overflow: hidden;
+        margin-right: 10px;
+        background-color: #e0e0e0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 500;
+        color: #333;
+        flex-shrink: 0;
+    }
+
+    .profile-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .profile-info {
+        max-width: 150px;
+        flex-grow: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .profile-name {
+        font-weight: 400;
+        font-size: 12px;
+        color: #666;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .profile-id {
+        font-weight: 400;
+        font-size: 12px;
+        color: #666;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .profile-dropdown {
+        margin-left: 4px;
+        color: var(--dark-gray);
+    }
+
+    /* 프로필 드롭다운 메뉴 */
+    .profile-menu {
+        position: absolute;
+        top: 55px;
+        right: 0;
+        background-color: white;
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-md);
+        width: 180px;
+        z-index: 1000;
+        display: none;
+        overflow: hidden;
+    }
+
+    .profile-menu-item {
+        padding: 12px 16px;
+        font-size: var(--font-sm);
+        color: #333;
+        display: flex;
+        align-items: center;
+        text-decoration: none;
+        transition: background-color var(--transition-speed);
+    }
+
+    .profile-menu-item:hover {
+        background-color: #f5f5f5;
+    }
+
+    .profile-menu-item svg {
+        margin-right: 10px;
+        width: 16px;
+        height: 16px;
+    }
+
+    .profile-menu-divider {
+        height: 1px;
+        background-color: var(--border-color);
+    }
+
+    .logout-item {
+        color: var(--danger-color);
+    }
+
+
+/* 헤더 모달 오버레이 */
+.header-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.header-modal-overlay.show {
+    opacity: 1;
+}
+
+/* 헤더 모달 컨테이너 */
+.header-modal-container {
+    background-color: white;
+    border-radius: 12px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    transform: scale(0.9);
+    transition: transform 0.3s ease;
+}
+
+.header-modal-overlay.show .header-modal-container {
+    transform: scale(1);
+}
+
+/* 헤더 모달 헤더 */
+.header-modal-header {
+    padding: 20px 24px;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.header-modal-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: #111827;
+    margin: 0;
+}
+
+.header-modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px;
+    color: #6b7280;
+    border-radius: 6px;
+    transition: all 0.2s;
+}
+
+.header-modal-close:hover {
+    background-color: #f3f4f6;
+    color: #111827;
+}
+
+/* 헤더 모달 바디 */
+.header-modal-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px;
+}
+/* 모달 오버레이 */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+/* 페이지네이션 스타일 */
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid #e5e7eb;
+}
+
+.pagination-btn {
+    padding: 8px 12px;
+    border: 1px solid #e5e7eb;
+    background-color: #fff;
+    color: #6b7280;
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+    min-width: 36px;
+    text-align: center;
+}
+
+.pagination-btn:hover:not(:disabled) {
+    background-color: #f9fafb;
+    border-color: #d1d5db;
+    color: #374151;
+}
+
+.pagination-btn.active {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: white;
+}
+
+.pagination-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.pagination-info {
+    font-size: 13px;
+    color: #6b7280;
+    margin: 0 12px;
+}
+
+.pagination-dots {
+    padding: 8px 4px;
+    color: #9ca3af;
+}
+
+.modal-overlay.show {
+    opacity: 1;
+}
+
+/* 모달 컨테이너 */
+.modal-container {
+    background-color: white;
+    border-radius: 12px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    transform: scale(0.9);
+    transition: transform 0.3s ease;
+}
+
+.modal-overlay.show .modal-container {
+    transform: scale(1);
+}
+
+/* 모달 헤더 */
+.modal-header {
+    padding: 20px 24px;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.modal-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: #111827;
+    margin: 0;
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px;
+    color: #6b7280;
+    border-radius: 6px;
+    transition: all 0.2s;
+}
+
+.modal-close:hover {
+    background-color: #f3f4f6;
+    color: #111827;
+}
+
+/* 모달 바디 */
+.modal-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px;
+}
+
+/* 필터 섹션 */
+.filter-section {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.checkbox-container {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+}
+
+.checkbox-container input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+}
+
+.checkbox-custom {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: #fff;
+    border: 2px solid #d1d5db;
+    border-radius: 4px;
+    margin-right: 8px;
+    transition: all 0.2s;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.checkbox-container input[type="checkbox"]:checked ~ .checkbox-custom {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+}
+
+.checkbox-custom::after {
+    content: '';
+    position: absolute;
+    display: none;
+    left: 6px;
+    top: 2px;
+    width: 4px;
+    height: 9px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.checkbox-container input[type="checkbox"]:checked ~ .checkbox-custom::after {
+    display: block;
+}
+
+.checkbox-label {
+    font-size: 14px;
+    color: #374151;
+    font-weight: 500;
+}
+
+.checkbox-container:hover .checkbox-custom {
+    border-color: #9ca3af;
+}
+
+.checkbox-container input[type="checkbox"]:checked:hover ~ .checkbox-custom {
+    background-color: #2563eb;
+    border-color: #2563eb;
+}
+
+/* 필터 결과 정보 */
+.filter-info {
+    font-size: 13px;
+    color: #6b7280;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.filter-count {
+    font-weight: 600;
+    color: #374151;
+}
+
+.no-results {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+/* 콘텐츠 리스트 */
+.content-list,
+.notification-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* 콘텐츠 아이템 */
+.content-item,
+.notification-item {
+    padding: 16px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    transition: all 0.2s;
+    cursor: pointer;
+}
+
+.content-item:hover,
+.notification-item:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.content-item.post {
+    background-color: #eff6ff;
+    border-color: #dbeafe;
+}
+
+.content-item.comment {
+    background-color: #f0fdf4;
+    border-color: #d1fae5;
+}
+
+.content-type {
+    font-size: 12px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.content-item.post .content-type {
+    color: #2563eb;
+}
+
+.content-item.comment .content-type {
+    color: #059669;
+}
+
+.content-type-icon {
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.content-type-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+.content-title {
+    font-size: 16px;
+    font-weight: 500;
+    color: #111827;
+    margin-bottom: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.content-preview {
+    font-size: 14px;
+    color: #6b7280;
+    line-height: 1.5;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    margin-bottom: 8px;
+}
+
+.content-meta {
+    font-size: 12px;
+    color: #9ca3af;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.content-meta span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* 알림 아이템 스타일 */
+.notification-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.notification-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #eff6ff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.notification-icon svg {
+    width: 20px;
+    height: 20px;
+    color: #3b82f6;
+}
+
+.notification-content {
+    flex: 1;
+}
+
+.notification-message {
+    font-size: 14px;
+    color: #374151;
+    margin-bottom: 4px;
+}
+
+.notification-time {
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.notification-item.unread {
+    background-color: #f0f9ff;
+    border-color: #bfdbfe;
+}
+
+/* 로딩 스피너 */
+.loading-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    min-height: 200px;
+}
+
+.loading-spinner {
+    position: relative;
+    width: 60px;
+    height: 60px;
+    margin-bottom: 20px;
+}
+
+.spinner-ring {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    border: 3px solid transparent;
+    border-radius: 50%;
+    animation: spin 1.5s linear infinite;
+}
+
+.spinner-ring:nth-child(1) {
+    border-top-color: #3b82f6;
+    animation-delay: -0.45s;
+}
+
+.spinner-ring:nth-child(2) {
+    border-right-color: #10b981;
+    animation-delay: -0.3s;
+}
+
+.spinner-ring:nth-child(3) {
+    border-bottom-color: #8b5cf6;
+    animation-delay: -0.15s;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.loading-text {
+    font-size: 14px;
+    color: #6b7280;
+    margin: 0;
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+/* 대체 로딩 스타일 - 도트 애니메이션 */
+.loading-dots {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 60px 20px;
+}
+
+.loading-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: #3b82f6;
+    animation: bounce 1.4s ease-in-out infinite both;
+}
+
+.loading-dot:nth-child(1) {
+    animation-delay: -0.32s;
+}
+
+.loading-dot:nth-child(2) {
+    animation-delay: -0.16s;
+}
+
+.loading-dot:nth-child(3) {
+    animation-delay: 0;
+}
+
+@keyframes bounce {
+    0%, 80%, 100% {
+        transform: scale(0);
+        opacity: 0.5;
+    }
+    40% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+/* 빈 상태 */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    text-align: center;
+}
+
+.empty-state svg {
+    color: #d1d5db;
+    margin-bottom: 16px;
+}
+
+.empty-state p {
+    font-size: 14px;
+    color: #6b7280;
+}
+
+.content-board {
+    font-size: 11px;
+    font-weight: 500;
+    color: #8b5cf6;
+    background-color: #f3e8ff;
+    padding: 2px 8px;
+    border-radius: 3px;
+    display: inline-block;
+    margin-bottom: 4px;
+}
+
+/* 알림 미리보기 스타일 추가 */
+.notification-preview {
+    font-size: 13px;
+    color: #9ca3af;
+    margin-top: 4px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+}
+@media (max-width: 640px) {
+    .modal-container {
+        width: 95%;
+        max-height: 90vh;
+    }
+    
+    .modal-header,
+    .modal-body {
+        padding: 16px 20px;
+    }
+    
+    .filter-section {
+        flex-wrap: wrap;
+    }
+}
+
+
+    /* 기존 스타일 유지 */
+    .tubelab-sidebar {
+        width: 220px;
+        height: 100vh;
+        position: fixed;
+        left: 0;
+        top: 0;
+        background-color: #ffffff;
+        border-right: 1px solid #e0e0e0;
+        z-index: 100;
+        transition: all 0.3s;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+    }
+    
+    .tubelab-sidebar.collapsed {
+        transform: translateX(-100%);
+        margin-left: -220px;
+    }
+    
+    .tubelab-sidebar .sidebar-logo {
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        height: 60px;
+        flex-shrink: 0;
+        border-bottom: 1px solid #eee;
+    }
+
+    .tubelab-sidebar .logo-box {
+        width: 32px;
+        height: 32px;
+        border-radius: 6px;
+        margin-right: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: hidden;
+    }
+    
+    .tubelab-sidebar .logo-box img {
+        max-width: 100%;
+        max-height: 100%;
+    }
+    
+    .tubelab-sidebar .logo-text {
+        font-size: 16px;
+        font-weight: 500;
+        color: #111;
+    }
+
+    .tubelab-sidebar .sidebar-menu {
+        padding: 10px 0;
+        flex-grow: 1;
+        overflow-y: auto;
+    }
+    
+    .tubelab-sidebar .menu-section {
+        margin-bottom: 5px;
+    }
+    
+    .tubelab-sidebar .menu-title {
+        display: flex;
+        align-items: center;
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: 500;
+        color: #111;
+        cursor: pointer;
+        text-decoration: none;
+        position: relative;
+    }
+    
+    .tubelab-sidebar .menu-title.has-submenu {
+        justify-content: space-between;
+    }
+    
+    .tubelab-sidebar .menu-title i {
+        width: 18px;
+        height: 18px;
+        margin-right: 10px;
+    }
+    
+    .tubelab-sidebar .menu-title .arrow {
+        width: 14px;
+        height: 14px;
+        transition: transform 0.2s;
+    }
+    
+    .tubelab-sidebar .menu-title.expanded .arrow {
+        transform: rotate(90deg);
+    }
+    
+    .tubelab-sidebar .menu-item {
+        padding: 8px 20px 8px 48px;
+        font-size: 14px;
+        color: #000000;
+        display: block;
+        text-decoration: none;
+        transition: background-color 0.2s;
+        position: relative;
+    }
+    
+    .tubelab-sidebar .menu-item:hover, 
+    .tubelab-sidebar .menu-title:hover {
+        background-color: #e9e9e9;
+    }
+    
+    .tubelab-sidebar .menu-item.active,
+    .tubelab-sidebar .menu-title.active {
+        background-color: #e5e5e5;
+        color: #111;
+        font-weight: 500;
+    }
+    
+    .tubelab-sidebar .divider {
+        height: 1px;
+        background-color: #e0e0e0;
+        margin: 10px 0;
+    }
+    
+    .tubelab-sidebar .section-title {
+        padding: 10px 20px;
+        font-size: 12px;
+        color: #999;
+        text-transform: uppercase;
+    }
+    
+    /* 로그인 유도 영역 */
+    .sidebar-login-prompt {
+        padding: 20px;
+        text-align: center;
+        border-bottom: 1px solid #eee;
+    }
+    
+    .login-message {
+        font-size: 14px;
+        color: #666;
+        margin-bottom: 15px;
+    }
+    
+    .login-button {
+        background-color: #FF0000;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        padding: 8px 16px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-block;
+        text-align: center;
+        transition: background-color 0.2s;
+    }
+    
+    .login-button:hover {
+        background-color: #E60000;
+    }
+    
+    .sidebar-close-button {
+        display: none;
+        position: absolute;
+        top: 15px;
+        right: 15px;
+        background: none;
+        border: none;
+        font-size: 24px;
+        color: rgb(255,80,80);
+        cursor: pointer;
+        z-index: 10;
+    }
+    
+    /* 알림 배지 스타일 추가 */
+    .notification-badge {
+        background-color: #ff0000;
+        color: white;
+        font-size: 10px;
+        font-weight: bold;
+        padding: 2px 5px;
+        border-radius: 10px;
+        margin-left: 5px;
+        display: inline-block;
+        min-width: 16px;
+        text-align: center;
+        line-height: 1.2;
+        vertical-align: middle;
+    }
+    
+    /* 메뉴 타이틀에서 배지 위치 */
+    .menu-title .notification-badge {
+        position: absolute;
+        right: 35px; /* 화살표 왼쪽에 위치 */
+        top: 50%;
+        transform: translateY(-50%);
+    }
+    
+    /* 화살표가 없는 메뉴의 경우 */
+    .menu-title:not(.has-submenu) .notification-badge {
+        right: 20px;
+    }
+    
+    /* 서브메뉴 아이템의 배지 */
+    .menu-item .notification-badge {
+        position: absolute;
+        right: 20px;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+
+    @media (max-width: 1024px) {
+        .tubelab-sidebar {
+            width: 100%;
+            transform: translateX(-100%);
+            z-index: 9999;
+        }
+        .sidebar-close-button {
+            display: block;
+        }
+        
+        .tubelab-sidebar.active {
+            transform: translateX(0);
+            margin-left: 0;
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
+        }
+    }
+
+    /* 레이아웃 관련 스타일 */
+    body.has-sidebar .main-content {
+        margin-left: 220px;
+    }
+
+    body.sidebar-collapsed .main-content {
+        margin-left: 0;
+    }
+    
+    @media (max-width: 768px) {
+        body.has-sidebar .main-content,
+        body.sidebar-collapsed .main-content,
+        .main-content {
+            margin-left: 0 !important;
+            width: 100% !important;
+        }
+        
+        .notification-badge {
+            font-size: 9px;
+            padding: 2px 4px;
+            min-width: 14px;
+        }
+    }
+    
+    /* 디버그 정보 스타일 */
+    .debug-info {
+        position: fixed;
+        bottom: 10px;
+        left: 10px;
+        background: rgba(0,0,0,0.8);
+        color: white;
+        padding: 10px;
+        font-size: 12px;
+        border-radius: 5px;
+        z-index: 10000;
+        max-width: 300px;
+    }
+    
+    /* 오류 메시지 스타일 */
+    .sidebar-error {
+        padding: 20px;
+        background-color: #fff3cd;
+        border: 1px solid #ffeaa7;
+        color: #856404;
+        margin: 10px;
+        border-radius: 5px;
+        font-size: 14px;
+    }
+


### PR DESCRIPTION
## Summary
- restructure src to match new file hierarchy
- convert old dashboard markup to React components
- add hooks and constants for dashboard
- include legacy CSS for styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687264c44fa0832a98e1875c41438db0